### PR TITLE
PHP version supports PUT, HEAD and OPTIONS methods

### DIFF
--- a/src/Pux/Mux.php
+++ b/src/Pux/Mux.php
@@ -7,6 +7,9 @@ define('REQ_METHOD_GET', 1);
 define('REQ_METHOD_POST', 2);
 define('REQ_METHOD_PUT', 3);
 define('REQ_METHOD_DELETE', 4);
+define('REQ_METHOD_PATCH', 5);
+define('REQ_METHOD_HEAD', 6);
+define('REQ_METHOD_OPTIONS', 7);
 
 class Mux
 {
@@ -106,10 +109,31 @@ class Mux
         $this->add($pattern, $callback, $options);
     }
 
-    public function post($pattern, $callback, $options = array()) {
+    public function post($pattern, $callback, $options = array())
+	{
         $options['method'] = REQ_METHOD_POST;
         $this->add($pattern, $callback, $options);
     }
+
+	public function patch($pattern, $callback, $options = array())
+	{
+		$options['method'] = REQ_METHOD_PATCH;
+		$this->add($pattern, $callback, $options);
+	}
+
+
+	public function head($pattern, $callback, $options = array())
+	{
+		$options['method'] = REQ_METHOD_HEAD;
+		$this->add($pattern, $callback, $options);
+	}
+
+
+	public function options($pattern, $callback, $options = array())
+	{
+		$options['method'] = REQ_METHOD_OPTIONS;
+		$this->add($pattern, $callback, $options);
+	}
 
     public function any($pattern, $callback, $options = array()) {
         $this->add($pattern, $callback, $options);
@@ -210,6 +234,12 @@ class Mux
             return REQ_METHOD_PUT;
         case "DELETE":
             return REQ_METHOD_DELETE;
+		case "PATCH":
+			return REQ_METHOD_PATCH;
+		case "HEAD":
+			return REQ_METHOD_HEAD;
+		case "OPTIONS":
+			return REQ_METHOD_OPTIONS;
         default:
             return 0;
         }


### PR DESCRIPTION
HTTP methods PUT, HEAD and OPTIONS are supported in the PHP version.
Extension (*.c and *.h files) were not updated yet so they do not
support these methods.
