### PR TITLE
allow empty @Route("") definitions

### DIFF
--- a/src/Pux/Controller.php
+++ b/src/Pux/Controller.php
@@ -48,7 +48,7 @@ class Controller {
                     $opts['method'] = $mux->getRequestMethodConstant(array_pop($mmatch));
                 }
 
-                if (preg_match('/^[\s*]*\@Route\("([^\s]+)"\)/im', $doc, $umatch)) {
+                if (preg_match('/^[\s*]*\@Route\("([^\s]*)"\)/im', $doc, $umatch)) {
                     $path[0] = array_pop($umatch);
                 }
             }


### PR DESCRIPTION
Minor, but allows us to do things like root-level routing relative to a mount point, e.g., if we mount a `Mux` at `/foo`, and want `FooController::barAction()` to be routable via `/foo` (so path `""` for the submux), we couldn't currently due this since it ignores empty paths; the best we could do before was `/foo/`.  
