### PR TITLE
Fixed default parameters not being passed to Controller Functions

### DIFF
--- a/src/Pux/Executor.php
+++ b/src/Pux/Executor.php
@@ -8,9 +8,9 @@ use ReflectionParameter;
 class Executor
 {
     /*
-     * $route: {pcre flag}, {pattern}, {callback}, {options} 
+     * $route: {pcre flag}, {pattern}, {callback}, {options}
      */
-    public static function execute($route) 
+    public static function execute($route)
     {
         list($pcre,$pattern,$cb,$options) = $route;
 
@@ -22,7 +22,7 @@ class Executor
             $constructArgs = $options['constructor_args'];
         }
 
-        // if the first argument is a class name string, 
+        // if the first argument is a class name string,
         // then create the controller object.
         if( is_string($cb[0]) ) {
             $cb[0] = $controller = $constructArgs ? $rc->newInstanceArgs($constructArgs) : $rc->newInstance();
@@ -34,7 +34,7 @@ class Executor
         if( $controller && ! method_exists( $controller ,$cb[1]) ) {
             throw new Exception('Controller exception');
             /*
-            throw new Exception('Method ' . 
+            throw new Exception('Method ' .
                 get_class($controller) . "->{$cb[1]} does not exist.", $route );
              */
         }
@@ -51,12 +51,12 @@ class Executor
         $arguments = array();
         foreach( $rps as $param ) {
             $n = $param->getName();
-            if( isset( $vars[ $n ] ) ) 
+            if( isset( $vars[ $n ] ) )
             {
                 $arguments[] = $vars[ $n ];
-            } 
-            else if( isset($route['default'][ $n ] )
-                            && $default = $route['default'][ $n ] )
+            }
+            else if( isset($route[3]['default'][ $n ] )
+                            && $default = $route[3]['default'][ $n ] )
             {
                 $arguments[] = $default;
             }


### PR DESCRIPTION
I ran into an issue with Pux where route parameters weren't properly being passed to Controller functions.

The following example would not return 'Hello World', but instead simply return 'Hello '

``` php
$routes->add('/hello/:name',
    ['Hello', 'world'],
    ['default' => ['name' => 'world']]
);

class Hello
{
    public function world($name)
    {
        return 'Hello ' . ucfirst($name);
    }
}

```

If I would define the world($name = 'world') then it would properly display, but settings defaults in the function as well as the route was redundant.  Looking into the executor class I noticed that the $route['default'] wasn't properly set, instead the Mux dispatcher always set variables/options/parameters in the $route[3] array.  Changing the default check to look for $route[3]['default'] made the router effortlessly pass default values to Controller functions.

Now with the same route as before, hitting /hello return 'Hello World'
