### PR TITLE
accept a callable function to `Mux::mount()` which can build a child mux

### DIFF
--- a/src/Pux/Mux.php
+++ b/src/Pux/Mux.php
@@ -68,6 +68,8 @@ class Mux
     {
         if ( $mux instanceof \Pux\Controller ) {
             $mux = $mux->expand();
+        } else if ((!is_object($mux) || !($mux instanceof Mux)) && is_callable($mux)) {
+            $mux($mux = new Mux());
         }
 
         if ( $this->expand ) {


### PR DESCRIPTION
example usage:

``` php
$mux = new Mux();
$mux->mount('/api', function(Mux $mux) {
    $mux->get('/endpoint', ['Controller', 'actionMethod']);
});
```

if you're okay with this addition I'll add a bunch of tests to cover it ( I just hate writing tests when the feature itself gets denied :P )
