### PR TITLE
Fixed odd behavory when using Mux::mount()

### DIFF
--- a/src/Pux/Mux.php
+++ b/src/Pux/Mux.php
@@ -71,11 +71,13 @@ class Mux
         }
 
         if ( $this->expand ) {
+            $pcre = strpos($pattern,':') !== false;
+
             // rewrite submux routes
             foreach( $mux->routes as $route ) {
                 // process for pcre
-                if ( $route[0] ) {
-                    $newPattern = $pattern . $route[3]['pattern'];
+                if ( $route[0] || $pcre ) {
+                    $newPattern = $pattern . ( $route[0] ? $route[3]['pattern'] : $route[1] );
                     $routeArgs = PatternCompiler::compile($newPattern, 
                         array_merge_recursive($route[3], $options) );
                     $this->appendPCRERoute( $routeArgs, $route[2] );

--- a/test/Pux/MuxMountTest.php
+++ b/test/Pux/MuxMountTest.php
@@ -98,4 +98,37 @@ class MuxMountTest extends MuxTestCase
         $this->assertPcreRoute($r, '/sub/hello/:name');
     }
 
+    public function testSubmuxPcreMount() {
+        $mux = new \Pux\Mux;
+        ok($mux);
+        is(0, $mux->length());
+
+        $submux = new \Pux\Mux;
+        $submux->any('/hello/:name', array( 'HelloController2','indexAction' ));
+        ok($submux);
+        ok($routes = $submux->getRoutes());
+        is(1, $submux->length());
+        is(0, $mux->length());
+        $mux->mount( '/sub/:country' , $submux);
+        $r = $mux->dispatch('/sub/UK/hello/John');
+        ok($r);
+        $this->assertPcreRoute($r, '/sub/:country/hello/:name');
+    }
+
+    public function testSubmuxPcreMountStaticSub() {
+        $mux = new \Pux\Mux;
+        ok($mux);
+        is(0, $mux->length());
+
+        $submux = new \Pux\Mux;
+        $submux->any('/hello/there', array( 'HelloController2','indexAction' ));
+        ok($submux);
+        ok($routes = $submux->getRoutes());
+        is(1, $submux->length());
+        is(0, $mux->length());
+        $mux->mount( '/sub/:country' , $submux);
+        $r = $mux->dispatch('/sub/UK/hello/there');
+        ok($r);
+        $this->assertPcreRoute($r, '/sub/:country/hello/there');
+    }
 }


### PR DESCRIPTION
Expanding a static route ontop of a mount containing a pattern was causing it to become completely static instead of staying a pcre route.

Tests added were initially failing and the 2nd commit fixed them.