### PR TITLE
Merging options nicely

### DIFF
--- a/src/Pux/Mux.php
+++ b/src/Pux/Mux.php
@@ -81,14 +81,14 @@ class Mux
                 if ( $route[0] || $pcre ) {
                     $newPattern = $pattern . ( $route[0] ? $route[3]['pattern'] : $route[1] );
                     $routeArgs = PatternCompiler::compile($newPattern, 
-                        array_merge_recursive($route[3], $options) );
+                        array_replace_recursive($options, $route[3]) );
                     $this->appendPCRERoute( $routeArgs, $route[2] );
                 } else {
                     $this->routes[] = array(
                         false,
                         $pattern . $route[1],
                         $route[2],
-                        isset($route[3]) ? array_merge($options, $route[3]) : $options,
+                        isset($route[3]) ? array_replace_recursive($options, $route[3]) : $options,
                     );
                 }
             }
@@ -231,7 +231,6 @@ class Mux
             return $this->submux[ $id ];
         }
     }
-
 
     public static function getRequestMethodConstant($method) {
         switch (strtoupper($method)) {

--- a/test/Pux/MuxMountTest.php
+++ b/test/Pux/MuxMountTest.php
@@ -121,14 +121,51 @@ class MuxMountTest extends MuxTestCase
         is(0, $mux->length());
 
         $submux = new \Pux\Mux;
-        $submux->any('/hello/there', array( 'HelloController2','indexAction' ));
+        $submux->any('/hello/there', array('HelloController2', 'indexAction'));
         ok($submux);
         ok($routes = $submux->getRoutes());
         is(1, $submux->length());
         is(0, $mux->length());
-        $mux->mount( '/sub/:country' , $submux);
+        $mux->mount('/sub/:country', $submux);
         $r = $mux->dispatch('/sub/UK/hello/there');
         ok($r);
         $this->assertPcreRoute($r, '/sub/:country/hello/there');
+    }
+
+    public function testSubmuxMergeOptions() {
+        $mux = new \Pux\Mux;
+        ok($mux);
+        is(0, $mux->length());
+
+        $submux = new \Pux\Mux;
+        $submux->any('/foo', array( 'HelloController2', 'indexAction' ), array(
+            'default' => array('suffix' => 'csv'),
+        ));
+        $submux->any('/hello/:name', array( 'HelloController2', 'indexAction' ), array(
+            'default' => array('suffix' => 'json')
+        ));
+        ok($submux);
+        ok($routes = $submux->getRoutes());
+        is(2, $submux->length());
+        is(0, $mux->length());
+        $mux->mount( '/sub', $submux, array(
+            'default' => array('suffix' => 'xml', 'prefix' => 'v1'),
+            'require' => array('suffix' => '[a-z]{3,4}')
+        ));
+        is(2, $mux->length());
+
+        $r = $mux->dispatch('/sub/hello/John');
+        ok($r);
+        ok($r[3]['default']['suffix'] == 'json');
+        ok($r[3]['default']['prefix'] == 'v1');
+        ok($r[3]['require']['suffix'] == '[a-z]{3,4}');
+        $this->assertPcreRoute($r, '/sub/hello/:name');
+
+        $r = $mux->dispatch('/sub/foo');
+        ok($r);
+        ok($r[3]['default']['suffix'] == 'csv');
+        ok($r[3]['default']['prefix'] == 'v1');
+        ok($r[3]['require']['suffix'] == '[a-z]{3,4}');
+        $this->assertNonPcreRoute($r, '/sub/foo');
     }
 }


### PR DESCRIPTION
As you can see in the test I've added the old code wouldn't merge recursively, as a result you couldn't set 'default' or 'require' options on a mount.

with these changes and the (already merged) change of being able to mount a lambda you can do stuff like the example below with overwriting options etc.

```php
// mount API
$mux->mount('', function(Mux $mux) {
    // mount v1 API
    $mux->mount('/v1/:network', function(Mux $mux) {
        // mount endpoints ...
        $mux->get('/block/:blockhash(.:format)', "BlockController:getBlock");
    }, [
        'default' => [
            'format' => 'xml'
        ],
        'require' => [ 'network' => '[a-zA-Z]{3,4}' ],
    ]);
}, [
    'domain' => 'api.blocktrail.com',
    'default' => [
        'network' => 'BTC',
        'format' => 'json'
    ],
    'require' => [
        'format' => 'json|csv|xml'
    ],
]);
```